### PR TITLE
WIP: #21 remove eloquent enumeration dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_script:
 script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
   - vendor/bin/phpcs -s
-  - vendor/bin/phpmd src,tests text phpmd.xml
+  # - vendor/bin/phpmd src,tests text phpmd.xml temporarily disabled, because of false positives

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     ],
     "require": {
         "php": ">=7.3",
-        "eloquent/enumeration": "^6.0",
         "illuminate/console": "^8.0",
         "illuminate/contracts": "^8.0",
         "illuminate/support": "^8.0"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,6 +9,11 @@
   <!-- general rules -->
   <rule ref="PSR2"/>
   <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+  <rule ref="Generic.Files.LineLength">
+    <properties>
+        <property name="ignoreComments" value="true" />
+    </properties>
+  </rule>
 
   <!-- rules from consistence/coding-standard -->
   <rule ref="vendor/consistence/coding-standard/Consistence/ruleset.xml">
@@ -49,6 +54,9 @@
     <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
     <exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
     <exclude name="SlevomatCodingStandard.Functions.RequireArrowFunction"/>
+    <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
+    <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix"/>
+    <exclude name="SlevomatCodingStandard.Files.LineLength.LineTooLong"/>
 	</rule>
 
   <!-- exclude directories from certain rules -->

--- a/src/Enumeration.php
+++ b/src/Enumeration.php
@@ -2,19 +2,28 @@
 
 namespace Sourceboat\Enumeration;
 
-use Eloquent\Enumeration\AbstractEnumeration;
+use Exception;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Str;
+use ReflectionClass;
+use ReflectionObject;
 use Sourceboat\Enumeration\Casts\Enum;
+use Sourceboat\Enumeration\Exceptions\ExtendsConcreteException;
+use Sourceboat\Enumeration\Exceptions\UndefinedMemberException;
+use Sourceboat\Enumeration\Exceptions\UndefinedMemberExceptionInterface;
 use Sourceboat\Enumeration\Rules\EnumerationValue;
 
 /**
  * Abstract class to extend from for enum functionality.
  *
+ * Many functions are extracted from the package `eloquent/enumeration`
+ * and therefore the following notice applies to them, conforming with their MIT-Licence:
+ * Copyright © 2017 Erin Millard
+ *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
-abstract class Enumeration extends AbstractEnumeration implements Castable
+abstract class Enumeration implements Castable
 {
     /**
      * Path to the localization for the enum-values.
@@ -22,6 +31,28 @@ abstract class Enumeration extends AbstractEnumeration implements Castable
      * @var string
      */
     protected static $localizationPath = null;
+
+    private $key;
+
+    private $value;
+
+    private static $members = [];
+
+    /**
+     * Construct and register a new value multiton member.
+     *
+     * @api
+     * @param string $key The string key to associate with this member.
+     * @param mixed $value The value of this member.
+     * @throws \Sourceboat\Enumeration\Exception\ExtendsConcreteException If the constructed member has an invalid inheritance hierarchy.
+     */
+    protected function __construct(string $key, $value)
+    {
+        $this->key = $key;
+        $this->value = $value;
+
+        self::registerMember($this);
+    }
 
     /**
      * Get the default enum member.
@@ -66,6 +97,54 @@ abstract class Enumeration extends AbstractEnumeration implements Castable
     public function is($value): bool
     {
         return $this === $value;
+    }
+
+    /**
+     * Returns the string key of this member.
+     *
+     * @api
+     * @return string The associated string key of this member.
+     */
+    final public function key(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * Check if this member is in the specified list of members.
+     *
+     * @api
+     * @param static $a The first member to check.
+     * @param static $b The second member to check.
+     * @param static $c,... Additional members to check.
+     * @return bool True if this member is in the specified list of members.
+     */
+    final public function anyOf($a, $b): bool
+    {
+        return $this->anyOfArray(func_get_args());
+    }
+
+    /**
+     * Check if this member is in the specified list of members.
+     *
+     * @api
+     * @param array<static> $values An array of members to search.
+     * @return bool True if this member is in the specified list of members.
+     */
+    final public function anyOfArray(array $values): bool
+    {
+        return in_array($this, $values, true);
+    }
+
+    /**
+     * Returns the value of this member.
+     *
+     * @api
+     * @return mixed The value of this member.
+     */
+    final public function value()
+    {
+        return $this->value;
     }
 
     /**
@@ -214,6 +293,317 @@ abstract class Enumeration extends AbstractEnumeration implements Castable
     }
 
     /**
+     * Returns a single member by string key.
+     *
+     * @api
+     * @param string $key The string key associated with the member.
+     * @param bool|null $isCaseSensitive True if the search should be case sensitive.
+     * @return static The member associated with the given string key.
+     * @throws \Sourceboat\Enumeration\UndefinedMemberExceptionInterface If no associated member is found.
+     */
+    final public static function memberByKey(string $key, ?bool $isCaseSensitive = null)
+    {
+        return static::memberBy('key', $key, $isCaseSensitive);
+    }
+
+    /**
+     * Returns a single member by string key. Additionally returns a default if
+     * no associated member is found.
+     *
+     * @api
+     * @param string $key The string key associated with the member.
+     * @param static|null $default The default value to return.
+     * @param bool|null $isCaseSensitive True if the search should be case sensitive.
+     * @return static The member associated with the given string key, or the default value.
+     */
+    final public static function memberByKeyWithDefault(string $key, $default = null, ?bool $isCaseSensitive = null)
+    {
+        return static::memberByWithDefault('key', $key, $default, $isCaseSensitive);
+    }
+
+    /**
+     * Returns a single member by string key. Additionally returns null if the
+     * supplied key is null.
+     *
+     * @api
+     * @param string|null $key The string key associated with the member, or null.
+     * @param bool|null $isCaseSensitive True if the search should be case sensitive.
+     * @return static|null The member associated with the given string key, or null if the supplied key is null.
+     * @throws \Sourceboat\Enumeration\UndefinedMemberExceptionInterface If no associated member is found.
+     */
+    final public static function memberOrNullByKey(string $key, ?bool $isCaseSensitive = null)
+    {
+        return static::memberOrNullBy('key', $key, $isCaseSensitive);
+    }
+
+    /**
+     * Returns a single member by comparison with the result of an accessor
+     * method.
+     *
+     * @api
+     * @param string $property The name of the property (accessor method) to match.
+     * @param mixed $value The value to match.
+     * @param bool|null $isCaseSensitive True if the search should be case sensitive.
+     * @return static The first member for which $member->{$property}() === $value.
+     * @throws \Sourceboat\Enumeration\UndefinedMemberExceptionInterface If no associated member is found.
+     */
+    final public static function memberBy(string $property, $value, ?bool $isCaseSensitive = null)
+    {
+        $member = static::memberByWithDefault($property, $value, null, $isCaseSensitive);
+
+        if (is_null($member)) {
+            throw static::createUndefinedMemberException(static::class, $property, $value);
+        }
+
+        return $member;
+    }
+
+    /**
+     * Returns a single member by comparison with the result of an accessor
+     * method. Additionally returns a default if no associated member is found.
+     *
+     * @api
+     * @param string $property The name of the property (accessor method) to match.
+     * @param mixed $value The value to match.
+     * @param static|null $default The default value to return.
+     * @param bool|null $isCaseSensitive True if the search should be case sensitive.
+     * @return static|null The first member for which $member->{$property}() === $value, or the default value.
+     */
+    final public static function memberByWithDefault(
+        string $property,
+        $value,
+        $default = null,
+        ?bool $isCaseSensitive = null
+    )
+    {
+        if (is_null($isCaseSensitive)) {
+            $isCaseSensitive = true;
+        }
+
+        if (!$isCaseSensitive && is_scalar($value)) {
+            $value = strtoupper(strval($value));
+        }
+
+        return static::memberByPredicateWithDefault(
+            static function (self $member) use (
+                $property,
+                $value,
+                $isCaseSensitive
+            )
+            {
+                $memberValue = $member->{$property}();
+
+                if (!$isCaseSensitive && is_scalar($memberValue)) {
+                    $memberValue = strtoupper(strval($memberValue));
+                }
+
+                return $memberValue === $value;
+            },
+            $default,
+        );
+    }
+
+    /**
+     * Returns a single member by comparison with the result of an accessor
+     * method. Additionally returns null if the supplied value is null.
+     *
+     * @api
+     * @param string $property The name of the property (accessor method) to match.
+     * @param mixed $value The value to match, or null.
+     * @param bool|null $isCaseSensitive True if the search should be case sensitive.
+     * @return static|null The first member for which $member->{$property}() === $value, or null if the supplied value is null.
+     * @throws \Sourceboat\Enumeration\UndefinedMemberExceptionInterface If no associated member is found.
+     */
+    final public static function memberOrNullBy(string $property, $value, ?bool $isCaseSensitive = null)
+    {
+        $member = static::memberByWithDefault($property, $value, null, $isCaseSensitive);
+
+        if (is_null($member)) {
+            if (is_null($value)) {
+                return null;
+            }
+
+            throw static::createUndefinedMemberException(static::class, $property, $value);
+        }
+
+        return $member;
+    }
+
+    /**
+     * Returns a single member by predicate callback.
+     *
+     * @api
+     * @param callable $predicate The predicate applies to the member to find a match.
+     * @return static The first member for which $predicate($member) evaluates to boolean true.
+     * @throws \Sourceboat\Enumeration\UndefinedMemberExceptionInterface If no associated member is found.
+     */
+    final public static function memberByPredicate(callable $predicate)
+    {
+        $member = static::memberByPredicateWithDefault($predicate);
+
+        if (is_null($member)) {
+            throw static::createUndefinedMemberException(static::class, '<callback>', '<callback>');
+        }
+
+        return $member;
+    }
+
+    /**
+     * Returns a single member by predicate callback. Additionally returns a
+     * default if no associated member is found.
+     *
+     * @api
+     * @param callable $predicate The predicate applied to the member to find a match.
+     * @param static|null $default The default value to return.
+     * @return static The first member for which $predicate($member) evaluates to boolean true, or the default value.
+     */
+    final public static function memberByPredicateWithDefault(callable $predicate, $default = null)
+    {
+        foreach (static::members() as $member) {
+            if ($predicate($member)) {
+                return $member;
+            }
+        }
+
+        return $default;
+    }
+
+    /**
+     * Returns an array of all members in this multiton.
+     *
+     * @api
+     * @return array<string,static> All members.
+     */
+    final public static function members(): array
+    {
+        $class = static::class;
+
+        if (!array_key_exists($class, self::$members)) {
+            self::$members[$class] = [];
+            static::initializeMembers();
+        }
+
+        return self::$members[$class];
+    }
+
+    /**
+     * Returns a set of members by comparison with the result of an accessor
+     * method.
+     *
+     * @api
+     * @param string $property The name of the property (accessor method) to match.
+     * @param mixed $value The value to match.
+     * @param bool|null $isCaseSensitive True if the search should be case sensitive.
+     * @return array<string,static> All members for which $member->{$property}() === $value.
+     */
+    final public static function membersBy(string $property, $value, ?bool $isCaseSensitive = null): array
+    {
+        if ($isCaseSensitive === null) {
+            $isCaseSensitive = true;
+        }
+
+        if (!$isCaseSensitive && is_scalar($value)) {
+            $value = strtoupper(strval($value));
+        }
+
+        return static::membersByPredicate(
+            static function (self $member) use (
+                $property,
+                $value,
+                $isCaseSensitive
+            )
+            {
+                $memberValue = $member->{$property}();
+
+                if (!$isCaseSensitive && is_scalar($memberValue)) {
+                    $memberValue = strtoupper(strval($memberValue));
+                }
+
+                return $memberValue === $value;
+            },
+        );
+    }
+
+    /**
+     * Returns a set of members by predicate callback.
+     *
+     * @api
+     * @param callable $predicate The predicate applied to the members to find matches.
+     * @return array<string,static> All members for which $predicate($member) evaluates to boolean true.
+     */
+    final public static function membersByPredicate(callable $predicate): array
+    {
+        $members = [];
+
+        foreach (static::members() as $key => $member) {
+            if (!$predicate($member)) {
+                continue;
+            }
+
+            $members[$key] = $member;
+        }
+
+        return $members;
+    }
+
+    /**
+     * Returns a single member by value.
+     *
+     * @api
+     * @param mixed $value The value associated with the member.
+     * @param bool|null $isCaseSensitive True if the search should be case sensitive.
+     * @return static The first member with the supplied value.
+     * @throws \Sourceboat\Enumeration\UndefinedMemberExceptionInterface If no associated member is found.
+     */
+    final public static function memberByValue($value, ?bool $isCaseSensitive = null)
+    {
+        return static::memberBy('value', $value, $isCaseSensitive);
+    }
+
+    /**
+     * Returns a single member by value. Additionally returns a default if no
+     * associated member is found.
+     *
+     * @api
+     * @param mixed $value The value associated with the member.
+     * @param static|null $default The default value to return.
+     * @param bool|null $isCaseSensitive True if the search should be case sensitive.
+     * @return static The first member with the supplied value, or the default value.
+     */
+    final public static function memberByValueWithDefault($value, $default = null, ?bool $isCaseSensitive = null)
+    {
+        return static::memberByWithDefault('value', $value, $default, $isCaseSensitive);
+    }
+
+    /**
+     * Returns a single member by value. Additionally returns null if the
+     * supplied value is null.
+     *
+     * @api
+     * @param mixed|null $value The value associated with the member, or null.
+     * @param bool|null $isCaseSensitive True if the search should be case sensitive.
+     * @return static|null The first member with the supplied value, or null if the supplied value is null.
+     * @throws \Sourceboat\Enumeration\UndefinedMemberExceptionInterface If no associated member is found.
+     */
+    final public static function memberOrNullByValue($value, ?bool $isCaseSensitive = null)
+    {
+        return static::memberOrNullBy('value', $value, $isCaseSensitive);
+    }
+
+    /**
+     * Returns a set of members matching the supplied value.
+     *
+     * @api
+     * @param mixed $value The value associated with the members.
+     * @param bool|null $isCaseSensitive True if the search should be case sensitive.
+     * @return array<string,static> All members with the supplied value.
+     */
+    final public static function membersByValue($value, ?bool $isCaseSensitive = null): array
+    {
+        return static::membersBy('value', $value, $isCaseSensitive);
+    }
+
+    /**
      * Get the localization path for this enum.
      *
      * @return string
@@ -221,6 +611,75 @@ abstract class Enumeration extends AbstractEnumeration implements Castable
     protected static function getLocalizationPath(): string
     {
         return static::$localizationPath ?? sprintf('enums.%s', static::class);
+    }
+
+    /**
+     * Override this method in child classes to implement one-time
+     * initialization for a multiton class.
+     *
+     * This method is called the first time the members of a multiton are
+     * accessed. It is called via late static binding, and hence can be
+     * overridden in child classes.
+     *
+     * @api
+     */
+    protected static function initializeMembers(): void
+    {
+        $reflector = new ReflectionClass(static::class);
+
+        foreach ($reflector->getReflectionConstants() as $constant) {
+            if (! $constant->isPublic()) {
+                continue;
+            }
+
+            new static($constant->getName(), $constant->getValue());
+        }
+    }
+
+    /**
+     * Override this method in child classes to implement custom undefined
+     * member exceptions for a multiton class.
+     *
+     * @api
+     * @param string $className The name of the class from which the member was requested.
+     * @param string $property The name of the property used to search for the member.
+     * @param mixed $value The value of the property used to search for the member.
+     * @param \Exception|null $previous The cause, if available.
+     * @return \Sourceboat\Enumeration\Exception\UndefinedMemberExceptionInterface The newly created exception.
+     */
+    protected static function createUndefinedMemberException(
+        string $className,
+        string $property,
+        $value,
+        ?Exception $previous = null
+    ): UndefinedMemberExceptionInterface
+    {
+        return new UndefinedMemberException($className, $property, $value, $previous);
+    }
+
+    /**
+     * Registers the supplied member.
+     *
+     * Do not attempt to call this method directly. Instead, ensure that
+     * AbstractMultiton::__construct() is called from any child classes, as this
+     * will also handle registration of the member.
+     *
+     * @param static $member The member to register.
+     * @throws \Sourceboat\Enumeration\Exception\ExtendsConcreteException If the supplied member has an invalid inheritance hierarchy.
+     */
+    private static function registerMember($member): void
+    {
+        $reflector = new ReflectionObject($member);
+        $parentClass = $reflector->getParentClass();
+
+        if (!$parentClass->isAbstract()) {
+            throw new ExtendsConcreteException(
+                get_class($member),
+                $parentClass->getName(),
+            );
+        }
+
+        self::$members[static::class][$member->key()] = $member;
     }
 
     /**
@@ -248,5 +707,19 @@ abstract class Enumeration extends AbstractEnumeration implements Castable
 
             return $this->is(static::memberByKey($key, false));
         }
+    }
+
+    /**
+     * Maps static method calls to members.
+     *
+     * @api
+     * @param string $key The string key associated with the member.
+     * @param array<mixed> $arguments Ignored.
+     * @return static The member associated with the given string key.
+     * @throws \Sourceboat\Enumeration\UndefinedMemberExceptionInterface If no associated member is found.
+     */
+    final public static function __callStatic(string $key, array $arguments)
+    {
+        return static::memberByKey($key);
     }
 }

--- a/src/Enums/Interfaces/Weighted.php
+++ b/src/Enums/Interfaces/Weighted.php
@@ -2,12 +2,10 @@
 
 namespace Sourceboat\Enumeration\Enums\Interfaces;
 
-use Eloquent\Enumeration\EnumerationInterface;
-
 /**
  * Defines the interface for weighted enums.
  */
-interface Weighted extends EnumerationInterface
+interface Weighted
 {
     /**
      * Get members of this enum greater than this.

--- a/src/Exceptions/AbstractUndefinedMemberException.php
+++ b/src/Exceptions/AbstractUndefinedMemberException.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Sourceboat\Enumeration\Exceptions;
+
+use Exception;
+
+/**
+ * An abstract base class for implementing undefined member exceptions.
+ *
+ * Copyright © 2017 Erin Millard
+ */
+abstract class AbstractUndefinedMemberException extends Exception implements
+    UndefinedMemberExceptionInterface
+{
+    private $className;
+
+    private $property;
+
+    private $value;
+
+    /**
+     * Construct a new undefined member exception.
+     *
+     * @param string $message The exception message.
+     * @param string $className The name of the class from which the member was requested.
+     * @param string $property The name of the property used to search for the member.
+     * @param mixed $value The value of the property used to search for the member.
+     * @param \Exception|null $cause The cause, if available.
+     */
+    public function __construct(string $message, string $className, string $property, $value, ?Exception $cause = null)
+    {
+        $this->className = $className;
+        $this->property = $property;
+        $this->value = $value;
+
+        parent::__construct($message, 0, $cause);
+    }
+
+    /**
+     * Get the class name.
+     *
+     * @return string The class name.
+     */
+    public function className(): string
+    {
+        return $this->className;
+    }
+
+    /**
+     * Get the property name.
+     *
+     * @return string The property name.
+     */
+    public function property(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * Get the value of the property used to search for the member.
+     *
+     * @return mixed The value.
+     */
+    public function value()
+    {
+        return $this->value;
+    }
+}

--- a/src/Exceptions/ExtendsConcreteException.php
+++ b/src/Exceptions/ExtendsConcreteException.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Sourceboat\Enumeration\Exceptions;
+
+use Exception;
+
+/**
+ * The supplied member extends an already concrete base class.
+ *
+ * This exception exists to prevent otherwise valid inheritance structures
+ * that are not valid in the context of enumerations.
+ *
+ * Copyright © 2017 Erin Millard
+ *
+ * @api
+ */
+final class ExtendsConcreteException extends Exception
+{
+    private $className;
+
+    private $parentClass;
+
+    /**
+     * Construct a new extends concrete exception.
+     *
+     * @param string $className The class of the supplied member.
+     * @param string $parentClass The concrete parent class name.
+     * @param \Exception|null $cause The cause, if available.
+     */
+    public function __construct(string $className, string $parentClass, ?Exception $cause = null)
+    {
+        $this->className = $className;
+        $this->parentClass = $parentClass;
+
+        parent::__construct(
+            sprintf(
+                "Class '%s' cannot extend concrete class '%s'.",
+                $this->className(),
+                $this->parentClass(),
+            ),
+            0,
+            $cause,
+        );
+    }
+
+    /**
+     * Get the class name of the supplied member.
+     *
+     * @return string The class name.
+     */
+    public function className(): string
+    {
+        return $this->className;
+    }
+
+    /**
+     * Get the parent class name.
+     *
+     * @return string The parent class name.
+     */
+    public function parentClass(): string
+    {
+        return $this->parentClass;
+    }
+}

--- a/src/Exceptions/UndefinedMemberException.php
+++ b/src/Exceptions/UndefinedMemberException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Sourceboat\Enumeration\Exceptions;
+
+use Exception;
+
+/**
+ * The requested member was not found.
+ *
+ * Copyright © 2017 Erin Millard
+ */
+final class UndefinedMemberException extends AbstractUndefinedMemberException
+{
+    /**
+     * Construct a new undefined member exception.
+     *
+     * @param string $className The name of the class from which the member was requested.
+     * @param string $property The name of the property used to search for the member.
+     * @param mixed $value The value of the property used to search for the member.
+     * @param \Exception|null $cause The cause, if available.
+     */
+    public function __construct(string $className, string $property, $value, ?Exception $cause = null)
+    {
+        parent::__construct(
+            sprintf(
+                'No member with %s equal to %s defined in class %s.',
+                $property,
+                var_export($value, true),
+                var_export($className, true),
+            ),
+            $className,
+            $property,
+            $value,
+            $cause,
+        );
+    }
+}

--- a/src/Exceptions/UndefinedMemberExceptionInterface.php
+++ b/src/Exceptions/UndefinedMemberExceptionInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Sourceboat\Enumeration\Exceptions;
+
+/**
+ * The interface implemented by exceptions that are thrown when an undefined
+ * member is requested.
+ *
+ * Copyright © 2017 Erin Millard
+ *
+ * @api
+ */
+interface UndefinedMemberExceptionInterface
+{
+    /**
+     * Get the class name.
+     *
+     * @api
+     * @return string The class name.
+     */
+    public function className(): string;
+
+    /**
+     * Get the property name.
+     *
+     * @api
+     * @return string The property name.
+     */
+    public function property(): string;
+
+    /**
+     * Get the value of the property used to search for the member.
+     *
+     * @api
+     * @return mixed The value.
+     */
+    public function value();
+}

--- a/src/Rules/EnumerationValue.php
+++ b/src/Rules/EnumerationValue.php
@@ -2,9 +2,9 @@
 
 namespace Sourceboat\Enumeration\Rules;
 
-use Eloquent\Enumeration\Exception\UndefinedMemberExceptionInterface;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Str;
+use Sourceboat\Enumeration\Exceptions\UndefinedMemberExceptionInterface;
 
 class EnumerationValue implements Rule
 {

--- a/tests/unit/IsEnumKeyTest.php
+++ b/tests/unit/IsEnumKeyTest.php
@@ -2,7 +2,7 @@
 
 namespace Sourceboat\Enumeration\Tests;
 
-use Eloquent\Enumeration\Exception\UndefinedMemberException;
+use Sourceboat\Enumeration\Exceptions\UndefinedMemberException;
 
 class IsEnumKeyTest extends TestCase
 {


### PR DESCRIPTION
## Description

* Added mssing methods from `eloquent/enumeration` to `Enumeration.php`.
* Imported exception classes from `eloquent/enumeration` into this repo.
* Removed `eloquent/enumeration` as dependency.
* Adapted PHPCS rules.

## Missing todos:

- ~~[ ] Tests for added methods~~