### PR TITLE
Laravel 9 Support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
         allowed-to-fail: [false]
         include:
           - php-versions: '8.1'
-            composer-arguments: ['']
+            composer-arguments: ''
             allowed-to-fail: false
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,8 +16,8 @@ jobs:
         allowed-to-fail: [false]
         include:
           - php-versions: '8.1'
-            composer-arguments: ['--prefer-lowest', '']
-            allowed-to-fail: true
+            composer-arguments: ['']
+            allowed-to-fail: false
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
     ],
     "require": {
         "php": ">=7.3",
-        "illuminate/console": "^8.0",
-        "illuminate/contracts": "^8.0",
-        "illuminate/support": "^8.0"
+        "illuminate/console": "^8.0|^9.0",
+        "illuminate/contracts": "^8.0|^9.0",
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0",
+        "orchestra/testbench": "^6.0|^7.0",
         "phpmd/phpmd": "^2.6",
         "phpunit/phpunit": "9.*",
         "slevomat/coding-standard": "7.0.14",
@@ -67,6 +67,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
- allow installation with illuminate 9
- make tests not allowed to fail with php 8.1