### PR TITLE
Exclude tests and configs from package installation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and configuration with "export-ignore".
+/.github            export-ignore
+/tests              export-ignore
+/.editorconfig      export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/phpcs.xml          export-ignore
+/phpmd.xml          export-ignore
+/phpunit.xml        export-ignore


### PR DESCRIPTION
Achieved by adding a `.gitattributes`-file.